### PR TITLE
Update installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@
 ```bash
 git clone https://github.com/cmu-l3/l1.git
 cd l1
-pip install -e .
 pip install -e verl
+pip install packaging
+pip install ninja
+pip install flash-attn --no-build-isolation
+pip install -e .
 ```
 
 


### PR DESCRIPTION
I encountered errors while setting up the environment. The installation order should start with `verl`, otherwise, it will report a missing `torch` error. Additionally, `flash-attention` should be installed manually to avoid errors. I have made the necessary modifications accordingly.